### PR TITLE
Added host port

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,13 @@ To get help adding a connection profile use
 
 Basically the following syntax
 
-    $ ssh-tunnel-manager profile add <NAME> <USER@HOST> [-i <FILE TO PRIVATE KEY>] [-p <PASSWORD>] [--password-interactive] [--default]
+    $ ssh-tunnel-manager profile add <NAME> <USER@HOST> [-port <HOST PORT>] [-i <FILE TO PRIVATE KEY>] [-p <PASSWORD>] [--password-interactive] [--default]
 
 **NAME** is the name you use on command line to specify the connection profile you want to use. You can create as many as you want, but use only one at a time
 
 **USER@HOST** specifies the _username_ you want to use to connect to the _host_ to tunnel thru.
+
+**HOST PORT** is the host port you connect to the _host_ to tunnel thru. defaults to port 22.
 
 **FILE TO PRIVATE KEY** is a SSH identity file you want to use. ie. ~/.ssh/id_dsa (**NOTE:** its _not_ the public key!)
 
@@ -178,4 +180,3 @@ ssh-tunnel-manager tunnel add -g services statservice 8086:statservice.qa.{ENV}.
 ssh-tunnel-manager -t db,services -v env:myteam
 
 ```
-

--- a/lib/actions/profile.js
+++ b/lib/actions/profile.js
@@ -32,7 +32,9 @@ module.exports = function(config) {
                     host: userAndHost[1],
                     username: userAndHost[0]
                 };
-
+            if (opts && opts.port) {
+                profile.port = opts.port;
+            }
             if (config.getConnectionProfile(name) && (!opts || !opts.force)) {
                 return Q.reject("Connection profile with name '" + C.cyan(name) + "' already exists. Remove the old one first with profile remove command");
             }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -28,6 +28,7 @@ function profiles() {
         .cmd().name('add').title('Add SSH connection profile').helpful()
             .arg().name('name').title('connection profile name').req().end()
             .arg().name('userAndHost').title('User and host').val(profileAction.validators.userAndHost).req().end()
+            .opt().name('port').title('Host port. Default is port 22').short('port').long('port').end()
             .opt().name('identity').title('Use path and file to private key identity file').short('i').long('identity').end()
             .opt().name('password').title('Use password authentication (not recommended)').short('p').long('password').end()
             .opt().name('password-input').title('Use password authentication (interactive mode)').long('password-interactive').flag().end()
@@ -72,4 +73,3 @@ function tunnels() {
         .end()
     ;
 }
-


### PR DESCRIPTION
Hi,

Thank you for this utility. My servers use other host ports than 22 so I needed a way to configure it in profile. Here is a tiny update.

Usage:

``` bash
ssh-tunnel-manager profile add qa sampleman@qagateway.de -port 7056 --default
```
